### PR TITLE
Fix. The CustomValidationAttribute.RequiresValidationContext property implementation added.

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CustomValidationAttribute.cs
@@ -112,6 +112,16 @@ namespace System.ComponentModel.DataAnnotations
             get { return _method; }
         }
 
+        public override bool RequiresValidationContext 
+        {
+            get 
+            {
+                // If attribute is not valid, throw an exception right away to inform the developer
+                ThrowIfAttributeNotWellFormed();
+                // We should return true when 2-parameter form of the validation method is used
+                return !_isSingleArgumentMethod;
+            }
+        }
         #endregion
 
         /// <summary>

--- a/src/System.ComponentModel.Annotations/tests/CustomValidationAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/CustomValidationAttributeTests.cs
@@ -34,6 +34,24 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         [Fact]
+        public static void RequiresValidationContext_return_false_for_valid_validation_type_and_one_arg_method() {
+            var attribute = new CustomValidationAttribute(typeof(CustomValidator), "CorrectValidationMethodOneArg");
+            Assert.False(attribute.RequiresValidationContext);
+
+            attribute = new CustomValidationAttribute(typeof(CustomValidator), "CorrectValidationMethodOneArgStronglyTyped");
+            Assert.False(attribute.RequiresValidationContext);
+        }
+
+        [Fact]
+        public static void RequiresValidationContext_return_true_for_valid_validation_type_and_two_arg_method() {
+            var attribute = new CustomValidationAttribute(typeof(CustomValidator), "CorrectValidationMethodTwoArgs");
+            Assert.True(attribute.RequiresValidationContext);
+
+            attribute = new CustomValidationAttribute(typeof(CustomValidator), "CorrectValidationMethodTwoArgsStronglyTyped");
+            Assert.True(attribute.RequiresValidationContext);
+        }
+
+        [Fact]
         public static void Validate_throws_InvalidOperationException_for_invalid_ValidatorType()
         {
             var attribute = new CustomValidationAttribute(null, "Does not matter");


### PR DESCRIPTION
This is a fix. The CustomValidationAttribute does not override the
RequiresValidationContext property so this property always returns false
due to base implementation despite of the fact that the Method parameter
can actually point to the method that requires validation context as a
second parameter.
MS Connect link:
https://connect.microsoft.com/VisualStudio/feedback/details/1820586/system-componentmodel-dataannotations-customvalidationattribute-does-not-correctly-implement-the-requiresvalidationcontext-property
